### PR TITLE
Fixing return in get_ttl and get_expiration

### DIFF
--- a/php_stubs/libaerospike-php-stubsv1.0.0.php
+++ b/php_stubs/libaerospike-php-stubsv1.0.0.php
@@ -4278,6 +4278,7 @@ namespace Aerospike {
         /**
          * Expiration is TTL (Time-To-Live).
          * Number of seconds until record expires.
+         * Returns NULL if TTL is set to Never Expire.
          */
         public function getTtl(): ?int {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4224,10 +4224,10 @@ impl Record {
     /// Expiration is TTL (Time-To-Live).
     /// Number of seconds until record expires.
     #[getter]
-    pub fn get_ttl(&self) -> Option<i32> {
+    pub fn get_ttl(&self) -> Option<u32> {
         match self._as.expiration {
-            NEVER_EXPIRE => (NEVER_EXPIRE as i32).into(),
-            secs => (secs as i32).into(),
+            NEVER_EXPIRE => None,
+            secs => (secs as u32).into(),
         }
     }
 


### PR DESCRIPTION
This pull request is supposed to resolve issue #63 

It fixes 3 issues :
1. Reading record's ttl via getTtl() method always returns 1 when TTL is set to some expiration (withing few years).
2. Reading record's ttl via getTtl() method returns random big int when TTL is set to never expire (-1)
3. Fixes return of get_expiration which was not returning proper Expiration object

Problems seems to be in src/lib.rs - _pub fn get_ttl(&self) -> Option\<u32>_ and _pub fn get_expiration(&self) -> Expiration_

Abount the first issue I think the concept of TTL implemented in that function's body is wrong.
It considers TTL to be number of seconds since CITRUSLEAF_EPOCH but in fact it is not.
TTL in secs variable is the amount of seconds since the present moment when the record will expire.

Due to this conception misunderstanding all the code that adds it to CITRUSLEAF_EPOCH and compares it with the now time is not necesary. In fact the following check if expiration > now never gets true and the functions always return (1 as u32).into();

Second issue is due to wrong comparison as NEVER_EXPIRE is not 0 but 0xFFFFFFFF. So when ttl = NEVER_EXPIRE it then actually goes to the second match and subsequently satisfy if expiration > now and efectively returns NEVER_EXPIRE + CITRUSLEAF_EPOCH - NOW. I was thinking to make get_ttl method return i32 type value in order to represent NEVER_EXPIRE as -1 but finally I decided that it can return NULL when NEVER_EXPIRE otherwise return u32 as the original TTL type use. 

