### PR TITLE
Add send key setter and getter to BatchWritePolicy

### DIFF
--- a/php_stubs/libaerospike-php-stubsv1.0.0.php
+++ b/php_stubs/libaerospike-php-stubsv1.0.0.php
@@ -3777,6 +3777,8 @@ namespace Aerospike {
 
         public $record_exists_action;
 
+        public $send_key;
+
         public function __construct() {}
 
         /**
@@ -3857,6 +3859,16 @@ namespace Aerospike {
         public function getDurableDelete(): bool {}
 
         public function setDurableDelete(bool $durable_delete) {}
+
+        /**
+         * SendKey determines to whether send user defined key in addition to hash digest on both reads and writes.
+         * If the key is sent on a write, the key will be stored with the record on
+         * the server.
+         * The default is to not send the user defined key.
+         */
+        public function getSendKey(): bool {}
+
+        public function setSendKey(bool $send_key) {}
     }
 
     /**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4796,6 +4796,16 @@ impl BatchWritePolicy {
     pub fn set_durable_delete(&mut self, durable_delete: bool) {
         self._as.durable_delete = durable_delete;
     }
+
+    #[getter]
+    pub fn get_send_key(&self) -> bool {
+        self._as.send_key
+    }
+
+    #[setter]
+    pub fn set_send_key(&mut self, send_key: bool) {
+        self._as.send_key = send_key;
+    }
 }
 
 impl Default for BatchWritePolicy {


### PR DESCRIPTION
We found that we can not set send_key to BatchWritePolicy. It seems it is missing setter and getter.